### PR TITLE
UX polish: spin guidance, reel animation, hints

### DIFF
--- a/src/core/Game.ts
+++ b/src/core/Game.ts
@@ -47,6 +47,7 @@ export class Game {
   private powerUpCount = 0;
   private goals: LevelGoal[] = [];
   private collectCounts: Record<string, number> = {};
+  private hintTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(app: Application) {
     this.app = app;
@@ -288,15 +289,22 @@ export class Game {
         break;
       case 'IDLE':
         this.showScene('game');
+        this.clearHintTimer();
+        this.slotGrid.clearHint();
         this.spinButton.setEnabled(this.spinsRemaining > 0);
         this.spinButton.setText(this.spinsRemaining > 0 ? 'SPIN' : 'DONE');
         this.slotGrid.setInteractive(false);
+        if (this.spinsRemaining > 0) {
+          this.spinButton.playAttention();
+          this.hud.showMessage('Press SPIN to start!', 2500);
+        }
         break;
       case 'MATCH3_PHASE':
         this.slotGrid.setInteractive(true);
         this.spinButton.setEnabled(false);
         this.spinButton.setText(`MOVES: ${this.movesRemaining}`);
         this.hud.showMessage('Drag to swap symbols!', 2000);
+        this.startHintTimer();
         break;
     }
   }
@@ -345,15 +353,11 @@ export class Game {
     this.spinButton.setEnabled(false);
 
     try {
-      // Animate spin out
-      await this.slotGrid.animateSpin();
-
-      // Generate new grid (allows initial matches for auto-resolve)
-      const gridData = this.slotGrid.generateGrid(this.currentLevelDef!.id);
-      this.match3.setGrid(gridData);
-
-      // Slot-style reel drop
-      await this.slotGrid.animateLand();
+      // Unified reel spin: scroll down old, generate new, scroll in new
+      await this.slotGrid.animateReelSpin(() => {
+        const gridData = this.slotGrid.generateGrid(this.currentLevelDef!.id);
+        this.match3.setGrid(gridData);
+      });
     } catch (err) {
       console.error('Spin error:', err);
       const gridData = this.slotGrid.generateGrid(this.currentLevelDef!.id);
@@ -443,6 +447,10 @@ export class Game {
   private async handleSwap(r1: number, c1: number, r2: number, c2: number): Promise<void> {
     if (this.fsm.state !== 'MATCH3_PHASE' || this.movesRemaining <= 0) return;
 
+    // Clear hint on any swap attempt and restart timer
+    this.slotGrid.clearHint();
+    this.clearHintTimer();
+
     // Disable interaction during swap animation
     this.slotGrid.setInteractive(false);
 
@@ -501,6 +509,7 @@ export class Game {
 
     // Re-enable interaction
     this.slotGrid.setInteractive(true);
+    this.startHintTimer();
 
     // Check if moves depleted
     if (this.movesRemaining <= 0) {
@@ -510,6 +519,8 @@ export class Game {
   }
 
   private endMatchPhase(): void {
+    this.clearHintTimer();
+    this.slotGrid.clearHint();
     this.slotGrid.setInteractive(false);
     this.fsm.transition('SCORING');
 
@@ -633,6 +644,24 @@ export class Game {
           grid[r][c] = createCell(weightedRandom(symbols), r, c);
         }
       }
+    }
+  }
+
+  private startHintTimer(): void {
+    this.clearHintTimer();
+    this.hintTimer = setTimeout(() => {
+      if (this.fsm.state !== 'MATCH3_PHASE') return;
+      const hint = this.match3.findHint();
+      if (hint) {
+        this.slotGrid.showHint(hint.r1, hint.c1, hint.r2, hint.c2);
+      }
+    }, 5000);
+  }
+
+  private clearHintTimer(): void {
+    if (this.hintTimer) {
+      clearTimeout(this.hintTimer);
+      this.hintTimer = null;
     }
   }
 }

--- a/src/match3/Match3Engine.ts
+++ b/src/match3/Match3Engine.ts
@@ -159,6 +159,23 @@ export class Match3Engine {
     return { cleared, score: cleared.length * GameConfig.baseSymbolScore * 3 };
   }
 
+  /** Find a valid swap hint — returns the first valid adjacent pair or null */
+  findHint(): { r1: number; c1: number; r2: number; c2: number } | null {
+    for (let r = 0; r < this.rows; r++) {
+      for (let c = 0; c < this.cols; c++) {
+        // Check right neighbor
+        if (c + 1 < this.cols && this.isValidSwap(r, c, r, c + 1)) {
+          return { r1: r, c1: c, r2: r, c2: c + 1 };
+        }
+        // Check down neighbor
+        if (r + 1 < this.rows && this.isValidSwap(r, c, r + 1, c)) {
+          return { r1: r, c1: c, r2: r + 1, c2: c };
+        }
+      }
+    }
+    return null;
+  }
+
   private determinePowerUp(match: MatchGroup): { row: number; col: number; type: PowerUpType } | null {
     if (match.cells.length >= 5) {
       const mid = match.cells[Math.floor(match.cells.length / 2)];

--- a/src/slots/SlotGrid.ts
+++ b/src/slots/SlotGrid.ts
@@ -60,6 +60,10 @@ export class SlotGrid extends Container {
   private shimmerGraphic: Graphics | null = null;
   private shimmerTween: gsap.core.Tween | null = null;
 
+  // Hint overlay
+  private hintGraphics: Graphics[] = [];
+  private hintTweens: gsap.core.Tween[] = [];
+
   // Drag state
   private dragStart: { row: number; col: number; px: number; py: number } | null = null;
   private isDragging = false;
@@ -335,56 +339,59 @@ export class SlotGrid extends Container {
     await tl.then();
   }
 
-  // Animate the spin: symbols roll upward and fade
-  async animateSpin(): Promise<void> {
-    const allSprites = this.cells.flat().filter(Boolean) as CellSprite[];
-    if (allSprites.length === 0) return;
+  /**
+   * Slot-style reel spin: current symbols scroll downward off-screen per column,
+   * then new grid is rendered and new symbols scroll down from above with bounce.
+   * Each column stops at a different time (left first, right last).
+   */
+  async animateReelSpin(generateNewGrid: () => void): Promise<void> {
+    const rows = GameConfig.rows;
+    const cols = GameConfig.cols;
+    const totalH = rows * (CELL + GAP) - GAP;
 
-    const tl = gsap.timeline();
-    for (let c = 0; c < GameConfig.cols; c++) {
-      for (let r = 0; r < GameConfig.rows; r++) {
+    // Phase 1: Scroll current symbols downward off-screen
+    const scrollOut = gsap.timeline();
+    for (let c = 0; c < cols; c++) {
+      for (let r = 0; r < rows; r++) {
         const sprite = this.cells[r]?.[c];
         if (sprite) {
-          tl.to(sprite, {
-            y: sprite.y - 300,
+          scrollOut.to(sprite, {
+            y: sprite.y + 500 + r * 40,
             alpha: 0,
             duration: 0.35,
             ease: 'power2.in',
-          }, c * 0.08 + r * 0.02);
+          }, c * 0.1 + r * 0.02);
         }
       }
     }
-    await tl.then();
-  }
+    await scrollOut.then();
 
-  // Slot-style reel drop animation: symbols fall from above per column
-  async animateLand(): Promise<void> {
-    this.renderGrid();
-    const rows = GameConfig.rows;
-    const cols = GameConfig.cols;
+    // Phase 2: Generate new grid data and render
+    generateNewGrid();
 
-    const tl = gsap.timeline();
-
+    // Phase 3: New symbols enter from above and scroll into place
+    const scrollIn = gsap.timeline();
     for (let c = 0; c < cols; c++) {
       for (let r = 0; r < rows; r++) {
         const sprite = this.cells[r]?.[c];
         if (sprite) {
           const targetY = sprite.y;
-          sprite.y = targetY - 600 - r * 60;
+          // Start above the grid, staggered per column
+          sprite.y = targetY - 600 - r * 50;
           sprite.alpha = 1;
 
-          const colDelay = c * 0.15;
+          const colDelay = c * 0.2;
           const rowDelay = r * 0.04;
 
-          tl.to(sprite, {
+          scrollIn.to(sprite, {
             y: targetY,
-            duration: 0.45,
+            duration: 0.5,
             ease: 'bounce.out',
           }, colDelay + rowDelay);
         }
       }
     }
-    await tl.then();
+    await scrollIn.then();
   }
 
   // Animate gravity drop for cells that moved down
@@ -466,6 +473,42 @@ export class SlotGrid extends Container {
     const sprite = this.cells[row]?.[col];
     if (sprite) return { x: sprite.x + CELL / 2, y: sprite.y + CELL / 2 };
     return null;
+  }
+
+  // --- Hint system ---
+
+  /** Show a subtle bounce on two cells to hint a valid swap */
+  showHint(r1: number, c1: number, r2: number, c2: number): void {
+    this.clearHint();
+    for (const [r, c] of [[r1, c1], [r2, c2]]) {
+      const sprite = this.cells[r]?.[c];
+      if (!sprite) continue;
+
+      // Gentle repeating bounce on the actual cell sprite
+      const tween = gsap.to(sprite.scale, {
+        x: 1.1, y: 1.1,
+        duration: 0.5,
+        yoyo: true,
+        repeat: -1,
+        ease: 'sine.inOut',
+      });
+      this.hintTweens.push(tween);
+    }
+  }
+
+  /** Remove hint animations and reset cell scales */
+  clearHint(): void {
+    for (const tween of this.hintTweens) tween.kill();
+    // Reset any hinted cell scales back to 1
+    for (const row of this.cells) {
+      for (const sprite of row) {
+        if (sprite) {
+          gsap.set(sprite.scale, { x: 1, y: 1 });
+        }
+      }
+    }
+    this.hintTweens = [];
+    this.hintGraphics = [];
   }
 
   // --- Drag-to-swap ---
@@ -582,8 +625,28 @@ class CellSprite extends Container {
     this.drawShapePath(g, shape, cx, cy, r);
     g.stroke({ color: lightColor, width: 2, alpha: 0.4 });
 
-    // 4. Inner shine (small white ellipse, upper-left)
-    g.ellipse(cx - r * 0.25, cy - r * 0.3, r * 0.35, r * 0.2);
+    // 4. Inner shine (adjusted per shape to stay within bounds)
+    let shineX = cx - r * 0.15;
+    let shineY = cy - r * 0.2;
+    let shineRx = r * 0.25;
+    let shineRy = r * 0.15;
+    if (shape === 'triangle') {
+      shineX = cx;
+      shineY = cy - r * 0.05;
+      shineRx = r * 0.2;
+      shineRy = r * 0.12;
+    } else if (shape === 'diamond') {
+      shineX = cx;
+      shineY = cy - r * 0.15;
+      shineRx = r * 0.2;
+      shineRy = r * 0.12;
+    } else if (shape === 'star') {
+      shineX = cx - r * 0.1;
+      shineY = cy - r * 0.15;
+      shineRx = r * 0.18;
+      shineRy = r * 0.1;
+    }
+    g.ellipse(shineX, shineY, shineRx, shineRy);
     g.fill({ color: 0xffffff, alpha: 0.3 });
   }
 

--- a/src/ui/SpinButton.ts
+++ b/src/ui/SpinButton.ts
@@ -100,6 +100,17 @@ export class SpinButton extends Container {
     this.btnLabel.text = text;
   }
 
+  /** Attention-grabbing animation to prompt the player to press SPIN */
+  playAttention(): void {
+    const tl = gsap.timeline();
+    tl.to(this.scale, { x: 1.15, y: 1.15, duration: 0.25, ease: 'back.out' });
+    tl.to(this.scale, { x: 1.0, y: 1.0, duration: 0.2, ease: 'power2.inOut' });
+    tl.to(this.scale, { x: 1.1, y: 1.1, duration: 0.2, ease: 'back.out' });
+    tl.to(this.scale, { x: 1.0, y: 1.0, duration: 0.15 });
+    // Bright glow flash
+    gsap.to(this.glowRing, { alpha: 0.7, duration: 0.3, yoyo: true, repeat: 2, ease: 'sine.inOut' });
+  }
+
   private drawButton(color: number): void {
     this.bg.clear();
     this.bg.roundRect(-80, -28, 160, 56, 28);


### PR DESCRIPTION
## Summary
- Spin button plays an attention-grabbing bounce + glow animation when entering IDLE state with spins remaining, plus a "Press SPIN to start!" HUD message
- Replaced the upward fly-away spin animation with a slot-style downward reel scroll (per-column stagger, bounce landing)
- Fixed inner shine ellipse rendering outside shape bounds on triangle, diamond, and star gems
- Added a hint system that subtly bounces two swappable cells after 5 seconds of inactivity during match-3 phase

## Test plan
- [ ] Start Level 1 → verify spin button bounces and glows, HUD shows "Press SPIN to start!"
- [ ] SPIN → verify symbols scroll downward off-screen per column, new symbols enter from above with staggered bounce
- [ ] Inspect triangle/diamond/star symbols → verify inner shine stays within shape boundaries
- [ ] Enter match-3 phase → wait 5 seconds → verify two cells gently pulse in size (subtle bounce hint)
- [ ] Make a swap → verify hint disappears and resets the 5s timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)