### PR TITLE
fix: update Claude Code hook format to nested hooks[] schema

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,13 +3,23 @@
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
-        "command": "cd /Users/eb/Documents/Projects/KefSlot && npx tsc --noEmit --pretty 2>&1 | tail -20"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd /Users/eb/Documents/Projects/KefSlot && npx tsc --noEmit --pretty 2>&1 | tail -20"
+          }
+        ]
       }
     ],
     "PreToolUse": [
       {
         "matcher": "Edit|Write",
-        "command": "case \"$CLAUDE_FILE_PATHS\" in *package-lock*|*dist/*|*node_modules/*) echo 'BLOCK: Protected file — edit manually' >&2; exit 2;; esac"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "case \"$CLAUDE_FILE_PATHS\" in *package-lock*|*dist/*|*node_modules/*) echo 'BLOCK: Protected file — edit manually' >&2; exit 2;; esac"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

This PR updates `.claude/settings.json` to conform to the current Claude Code hook schema, which requires hook commands to be wrapped in a `hooks` array with typed entries.

**What changed:**
- Both `PostToolUse` and `PreToolUse` hook entries now use the `hooks: [{ type: "command", command: "..." }]` format instead of the flat `command: "..."` field
- Added missing newline at end of file

**Why this is needed:**
The flat `command` field format is no longer recognized by Claude Code. Without this fix, the auto type-check hook (runs `tsc --noEmit` after every Edit/Write) and the protected-file block hook (prevents edits to `package-lock.json`, `dist/`, `node_modules/`) silently fail to execute — removing important guardrails from the dev workflow.

@elibarnett — flagging for your review. This is a config-only change, no game logic touched.