### PR TITLE
Add kie-art MCP config, protect local settings, document Claude Code setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ src/assets/raw/
 # MCP server deps
 tools/kie-mcp/node_modules/
 
+# MCP config (machine-specific — create your own, see README)
+.mcp.json
+
 # Claude Code local overrides (personal API keys, machine-specific settings)
 .claude/settings.local.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@ src/assets/raw/
 # MCP server deps
 tools/kie-mcp/node_modules/
 
-# MCP config (contains API keys)
-.mcp.json
+# Claude Code local overrides (personal API keys, machine-specific settings)
+.claude/settings.local.json
 
 # iOS build artifacts (keep ios/ project tracked, exclude build output)
 ios/App/build/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "kie-art": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["tools/kie-mcp/server.mjs"]
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,0 @@
-{
-  "mcpServers": {
-    "kie-art": {
-      "type": "stdio",
-      "command": "node",
-      "args": ["tools/kie-mcp/server.mjs"]
-    }
-  }
-}

--- a/README.md
+++ b/README.md
@@ -210,4 +210,61 @@ Core gameplay loop is functional end-to-end. See the [wiki](https://github.com/K
 
 ---
 
+---
+
+## Claude Code Setup
+
+This repo ships with Claude Code automations in `.claude/` — skills, hooks, and an AI art MCP.
+
+### Skills (slash commands)
+
+Nine skills are available when working in this repo:
+
+| Command | What it does |
+|---------|-------------|
+| `/dev` | Start the Vite dev server on port 3005 |
+| `/build` | Type-check + production build |
+| `/pr` | Full git workflow — lint, type-check, commit, push, open PR |
+| `/mobile-preview` | Build + cap sync → open Xcode or Android Studio |
+| `/sync-claude-md` | Audit CLAUDE.md against disk and update it |
+| `/new-mechanic` | Scaffold a new mechanic in `MechanicsEngine.ts` |
+| `/art-asset` | Generate AI art via kie.ai, process images, check credits |
+| `/test-setup` | Scaffold vitest for the project |
+| `/test-run` | Run vitest suite and interpret results |
+
+To make these available **globally in all repos**, copy `.claude/skills/` to `~/.claude/skills/`.
+
+### kie-art MCP (AI art generation)
+
+The kie-art MCP server lives in `tools/kie-mcp/server.mjs` and is registered for this project via `.mcp.json`.
+
+**Setup — set your API key:**
+
+Add to `~/.claude/settings.local.json` (gitignored, never committed):
+```json
+{
+  "env": {
+    "KIE_API_KEY": "your-key-here"
+  }
+}
+```
+Or add `export KIE_API_KEY=your-key-here` to your shell profile (`~/.zshrc` / `~/.bashrc`).
+
+Get a key at [kie.ai](https://kie.ai).
+
+**To use kie-art in other repos globally**, add to `~/.claude/settings.json`:
+```json
+{
+  "mcpServers": {
+    "kie-art": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/Users/db/repos/KefSensei/kefslot/tools/kie-mcp/server.mjs"]
+    }
+  }
+}
+```
+
+---
+
 *© KefSensei. All rights reserved.*


### PR DESCRIPTION
## Summary
- Add `.mcp.json` (committed, no secrets) so the kie-art MCP is auto-available to anyone cloning the repo
- Remove `.mcp.json` from `.gitignore` — it's safe to commit now that the API key is gone
- Add `.claude/settings.local.json` to `.gitignore` — the right place for personal API keys and machine-specific overrides
- Add `## Claude Code Setup` section to README with skills table, MCP key setup instructions, and global config snippet

## Test plan
- [ ] Clone the repo fresh → `kie-art` MCP appears in Claude Code without any extra config
- [ ] Add `KIE_API_KEY` to `~/.claude/settings.local.json` → `/art-asset` works
- [ ] Confirm `.claude/settings.local.json` does not appear in `git status`
- [ ] README Claude Code section renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)